### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/TimeAgo.php
+++ b/src/TimeAgo.php
@@ -30,7 +30,7 @@ class TimeAgo extends Plugin
         self::$plugin = $this;
 
         // Add in our Twig extensions
-        Craft::$app->view->twig->addExtension(new twigextensions\TimeAgoTwigExtension());
+        Craft::$app->view->registerTwigExtension(new twigextensions\TimeAgoTwigExtension());
 
         Craft::info(
             Craft::t(


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.